### PR TITLE
circuit: add number_of_qubits to the quantum_circuit job payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix and improve error handing from individual circuits #24
+* Add `number_of_qubits` to the `quantum_circuit` job payload #29
 
 ## qiskit-aqt-provider v0.8.1
 

--- a/qiskit_aqt_provider/circuit_to_aqt.py
+++ b/qiskit_aqt_provider/circuit_to_aqt.py
@@ -165,6 +165,10 @@ def circuit_to_aqt_new(circuit: QuantumCircuit, shots: int) -> Dict[str, Any]:
     out_dict = {
         "job_type": "quantum_circuit",
         "label": "qiskit",
-        "payload": {"repetitions": shots, "quantum_circuit": seqs},
+        "payload": {
+            "repetitions": shots,
+            "quantum_circuit": seqs,
+            "number_of_qubits": circuit.num_qubits,
+        },
     }
     return out_dict

--- a/test/test_circuit_to_aqt_new.py
+++ b/test/test_circuit_to_aqt_new.py
@@ -35,7 +35,11 @@ def test_just_measure_circuit() -> None:
     expected = {
         "job_type": "quantum_circuit",
         "label": "qiskit",
-        "payload": {"quantum_circuit": [{"operation": "MEASURE"}], "repetitions": shots},
+        "payload": {
+            "quantum_circuit": [{"operation": "MEASURE"}],
+            "repetitions": shots,
+            "number_of_qubits": 1,
+        },
     }
 
     result = circuit_to_aqt_new(qc, shots=shots)
@@ -57,6 +61,7 @@ def test_valid_circuit() -> None:
         "job_type": "quantum_circuit",
         "label": "qiskit",
         "payload": {
+            "number_of_qubits": 2,
             "repetitions": 1,
             "quantum_circuit": [
                 {
@@ -120,6 +125,7 @@ def test_invalid_measurements() -> None:
         "job_type": "quantum_circuit",
         "label": "qiskit",
         "payload": {
+            "number_of_qubits": 2,
             "repetitions": 1,
             "quantum_circuit": [
                 {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch adds the new `number_of_qubits` field to the `quantum_circuit` job payload.


