### PR TITLE
transpiler: fix substitution circuit for wrapping the Rxx angles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix and improve error handing from individual circuits #24
 * Run the examples in the continuous integration pipeline #26
 * Add `number_of_qubits` to the `quantum_circuit` job payload #29
+* Fix substitution circuit for wrapping the `Rxx` angles #30
 
 ## qiskit-aqt-provider v0.8.1
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch fixes the substitution circuit for wrapping the angle of `Rxx`  operations.

Prior to this patch, constructions like the following would produce a Qiskit error:

```python
qc = QuantumCircuit(4)
qc.rxx(4*pi/3, 0, 1)
```

```
qiskit.dagcircuit.exceptions.DAGCircuitError: 'bit mapping invalid: expected 2, got 4'
```

### Details and comments

- **Regression**: transpiling with optimization level 0 does not produce executable circuits anymore, because the custom instructions are not decomposed there. This should not be problematic in real use cases.
- This also removes the occurrences of the following warning stemming from the `transpiler_plugin` module:

```
  /home/runner/work/qiskit-aqt-provider-internal/qiskit-aqt-provider-internal/qiskit_aqt_provider/transpiler_plugin.py:61: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.
    qr = {q0.register, q1.register}
```

Back-references from `Bit` instances to containing `Registers` are still used in the quantum-to-classical registers mapping code.