### PR TITLE
workflows/release: use correct tag name in extract-changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           path: ./dist/qiskit*
       - name: Extract changelog
-        run: python scripts/extract-changelog.py ${{ github.ref }} | tee ${{ github.workspace }}-CHANGELOG.txt
+        run: python scripts/extract-changelog.py ${{ github.ref_name }} | tee ${{ github.workspace }}-CHANGELOG.txt
       - name: Create Github release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix the release workflow: the short tag name is [`github.ref_name`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), not `github.ref`.

