### PR TITLE
workflows/poetry: create HTML coverage artifact

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -49,6 +49,13 @@ jobs:
         run: poetry run poe test --cov_opts="-a"  # add to examples coverage
       - name: Docs
         run: poetry run poe docs
+      - name: Generate HTML coverage report
+        run: poetry run coverage html
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-coverage
+          path: htmlcov/
       - name: Generate XML coverage report
         run: poetry run coverage xml -o coverage.xml
       - name: Read global coverage target


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch uploads the HTML coverage report as workflow artifact.

There's [apparently](https://github.com/actions/upload-artifact/issues/14) no easy way to display the artifact directly in the browser, so it must be downloaded for inspect. But that's better than nothing.

