### PR TITLE
workflows: update checkout and setup-python actions

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -17,15 +17,16 @@ jobs:
         poetry-version: [1.4.1]
         os: ["ubuntu-latest"]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
       - name: Install poetry
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
       - name: Check Poetry lock file status
         run: poetry lock --check
       - name: Check shell scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Install Poetry


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The Github actions runner is warning about the `actions/checkout` and `actions/setup-python` actions still using Node12 instead of Node16. Update these actions to their latest stable branch.

### Details and comments

- enable [caching](https://github.com/actions/setup-python/blob/3091b37310257c35e28f059cf05d8c8c74250b17/docs/advanced-usage.md#caching-packages) for Poetry packages in `setup-python`.
