### PR TITLE
job/result: expose raw bitstrings through result.get_memory()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Expose the result polling period and timeout as backend options #46
+* Support `qiskit.result.Result.get_memory()` to retrieve the raw results bitstrings #48
 
 ## qiskit-aqt-provider v0.10.0
 

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -17,6 +17,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
+    Any,
     ClassVar,
     DefaultDict,
     Dict,
@@ -151,11 +152,14 @@ class AQTJob(JobV1):
 
         # jobs order is submission order
         for circuit, result in zip(self.circuits, self._jobs.values()):
-            data = {}
+            data: Dict[str, Any] = {}
 
             if isinstance(result, JobFinished):
                 meas_map = _build_memory_mapping(circuit)
                 data["counts"] = _format_counts(result.samples, meas_map)
+                data["memory"] = [
+                    "".join(str(x) for x in reversed(shots)) for shots in result.samples
+                ]
 
             results.append(
                 {

--- a/qiskit_aqt_provider/aqt_resource.py
+++ b/qiskit_aqt_provider/aqt_resource.py
@@ -107,7 +107,7 @@ class AQTResource(Backend):
                 "coupling_map": None,
                 "description": "AQT trapped-ion device simulator",
                 "basis_gates": ["r", "rz", "rxx"],  # the actual basis gates
-                "memory": False,
+                "memory": True,
                 "n_qubits": num_qubits,
                 "conditional": False,
                 "max_shots": 200,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch enables using `result.get_memory()` to access the raw bitstrings for each shot after a circuit execution.

### Details and comments

- the `memory` option (e.g. passed in `backend.run()`) has no effect: the classical memory is always available, since this is what the AQT cloud computing API returns and the standard counts are calculated in the provider code.
