### PR TITLE
timeout: remove busy loop

### DIFF
--- a/qiskit_aqt_provider/test/timeout.py
+++ b/qiskit_aqt_provider/test/timeout.py
@@ -13,7 +13,6 @@
 """Timeout utilities for tests."""
 
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Iterator
@@ -31,15 +30,12 @@ def timeout(seconds: float) -> Iterator[None]:
     """
     stop = threading.Event()
 
-    def counter(deadline: float) -> None:
-        while time.time() < deadline:
-            if stop.is_set():
-                return
-
-        raise TimeoutError
+    def counter(duration: float) -> None:
+        if not stop.wait(duration):
+            raise TimeoutError
 
     with ThreadPoolExecutor(max_workers=1, thread_name_prefix="timeout_") as pool:
-        task = pool.submit(counter, deadline=time.time() + seconds)
+        task = pool.submit(counter, duration=seconds)
         yield
 
         stop.set()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch improves on the implementation of the `timeout` context manager by removing the busy loop in the worker thread. Thanks @wilfried-huss for the hint!
