### PR TITLE
dependencies: retrict qiskit-terra below 0.24.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4316,4 +4316,4 @@ examples = ["tweedledum"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "cc8e5364dc4ac98d3d8118c0efdda4319198bae6f784ee67bd50a6ef512b6425"
+content-hash = "6037efe4646e0467d4aa5b959891e4fe0cc254d17d3ff92bc0faeda46e453c8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ httpx = ">=0.24.0"
 pydantic = ">=1.10,<2"
 python-dotenv = ">=1"
 qiskit-aer = ">=0.11"
-qiskit-terra = ">=0.23.3"
+qiskit-terra = ">=0.23.3,<0.24.0"
 tabulate = ">=0.9.0"
 tqdm = ">=4"
 tweedledum = { version = ">=1", optional = true }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`qiskit-terra` [0.24.0](https://github.com/Qiskit/qiskit-terra/releases/tag/0.24.0) was released on 2023-05-04. :tada:

This patch prevents selecting this new release during dependency resolution for this package as it breaks transpilation at optimization level 3 (see qiskit/qiskit-terra#10082).
