### PR TITLE
tests: use function-scoped contexts, show context data in report

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Docs
         run: poetry run poe docs
       - name: Generate HTML coverage report
-        run: poetry run coverage html
+        run: poetry run coverage html --show-contexts
       - name: Upload HTML coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,9 @@ extend-exclude = [
 [tool.ruff.pydocstyle]
 convention = "google"
 
+[tool.coverage.run]
+dynamic_context = "test_function"
+
 [tool.coverage.report]
 fail_under = 98
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch enables function-scoped [coverage contexts](https://coverage.readthedocs.io/en/7.2.5/contexts.html) in tests.

Contexts are rendered in the HTML coverage report and show which test functions cover which lines of the code. For example in `aqt_resource.py`:

![image](https://github.com/alpine-quantum-technologies/qiskit-aqt-provider-rc/assets/44871469/2f39b1a4-ee7a-4857-82f6-77d96cb9ac1c)
