### PR TITLE
Add specialized Estimator primitive and VQE example 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add `AQTEstimator`, a specialized implementation of the `Estimator` primitive #71
+* Add simple VQE example #71
+
 ## qiskit-aqt-provider v0.13.0
 
 * Always raise `TranspilerError` on errors in the custom transpilation passes #57

--- a/examples/vqe.py
+++ b/examples/vqe.py
@@ -1,0 +1,51 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Trivial minimization example using a variational quantum eigensolver."""
+
+from typing import Final
+
+from qiskit.algorithms.minimum_eigensolvers import VQE
+from qiskit.algorithms.optimizers import COBYLA
+from qiskit.circuit.library import TwoLocal
+from qiskit.quantum_info import SparsePauliOp
+from qiskit.utils import algorithm_globals
+
+from qiskit_aqt_provider import AQTProvider
+from qiskit_aqt_provider.aqt_resource import OfflineSimulatorResource
+from qiskit_aqt_provider.primitives.estimator import AQTEstimator
+
+RANDOM_SEED: Final = 0
+
+if __name__ == "__main__":
+    backend = AQTProvider("token").get_backend("offline_simulator_no_noise")
+    assert isinstance(backend, OfflineSimulatorResource)
+    estimator = AQTEstimator(backend)
+
+    # fix the random seeds such that the example is reproducible
+    algorithm_globals.random_seed = RANDOM_SEED
+    backend.simulator.options.seed_simulator = RANDOM_SEED
+
+    # Hamiltonian: Ising model on two spin 1/2 without external field
+    J = 1.2
+    hamiltonian = SparsePauliOp.from_list([("XX", J)])
+
+    # Find the ground-state energy with VQE
+    ansatz = TwoLocal(num_qubits=2, rotation_blocks="ry", entanglement_blocks="rxx", reps=1)
+    optimizer = COBYLA(maxiter=100, tol=0.01)
+    vqe = VQE(estimator, ansatz, optimizer)
+    result = vqe.compute_minimum_eigenvalue(operator=hamiltonian)
+    assert result.eigenvalue is not None
+
+    print(f"Optimizer run time: {result.optimizer_time:.2f} s")
+    print("Cost function evaluations:", result.cost_function_evals)
+    print("Deviation from expected ground-state energy:", abs(result.eigenvalue - (-J)))

--- a/qiskit_aqt_provider/primitives/estimator.py
+++ b/qiskit_aqt_provider/primitives/estimator.py
@@ -13,14 +13,14 @@
 from copy import copy
 from typing import Any, Dict, Optional
 
-from qiskit.primitives import BackendSampler
+from qiskit.primitives import BackendEstimator
 
 from qiskit_aqt_provider import transpiler_plugin
 from qiskit_aqt_provider.aqt_resource import AQTResource, make_transpiler_target
 
 
-class AQTSampler(BackendSampler):
-    """Sampler primitive for AQT backends."""
+class AQTEstimator(BackendEstimator):
+    """Estimator primitive for AQT backends."""
 
     _backend: AQTResource
 
@@ -28,13 +28,15 @@ class AQTSampler(BackendSampler):
         self,
         backend: AQTResource,
         options: Optional[Dict[str, Any]] = None,
+        abelian_grouping: bool = True,
         skip_transpilation: bool = False,
     ):
-        """Initialize a Sampler primitive for AQT resources.
+        """Initialize an Estimator primitive for AQT resources.
 
         Args:
             backend: AQT resource to evaluate circuits on
             options: options passed to the base sampler
+            abelian_grouping:  whether the observable should be grouped into commuting parts
             skip_transpilation: if true, pass circuits unchanged to the backend.
         """
         # Signal the transpiler to disable passes that require bound
@@ -54,6 +56,7 @@ class AQTSampler(BackendSampler):
             mod_backend,
             bound_pass_manager=transpiler_plugin.bound_pass_manager(mod_backend.target),
             options=options_copy,
+            abelian_grouping=abelian_grouping,
             skip_transpilation=skip_transpilation,
         )
 

--- a/qiskit_aqt_provider/transpiler_plugin.py
+++ b/qiskit_aqt_provider/transpiler_plugin.py
@@ -40,7 +40,7 @@ def bound_pass_manager(target: Target) -> PassManager:
     """Transpilation passes to apply on circuits after the parameters are bound.
 
     This assumes that a preset pass manager was applied to the unbound circuits
-    (by setting the target to an instance of `UnboundParametersTarget`.
+    (by setting the target to an instance of `UnboundParametersTarget`).
 
     Args:
         target: transpilation target.

--- a/qiskit_aqt_provider/transpiler_plugin.py
+++ b/qiskit_aqt_provider/transpiler_plugin.py
@@ -23,6 +23,7 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler import Target
 from qiskit.transpiler.basepasses import BasePass, TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.passes import Decompose, Optimize1qGatesDecomposition
 from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import common
@@ -33,6 +34,29 @@ from qiskit_aqt_provider.utils import map_exceptions
 
 class UnboundParametersTarget(Target):
     """Target that disables passes that require bound parameters."""
+
+
+def bound_pass_manager(target: Target) -> PassManager:
+    """Transpilation passes to apply on circuits after the parameters are bound.
+
+    This assumes that a preset pass manager was applied to the unbound circuits
+    (by setting the target to an instance of `UnboundParametersTarget`.
+
+    Args:
+        target: transpilation target.
+    """
+    return PassManager(
+        [
+            # wrap the Rxx angles
+            WrapRxxAngles(),
+            # decompose the substituted Rxx gates
+            Decompose([f"{WrapRxxAngles.SUBSTITUTE_GATE_NAME}*"]),
+            # collapse the single qubit runs as ZXZ
+            Optimize1qGatesDecomposition(target=target),
+            # wrap the Rx angles, rewrite as R
+            RewriteRxAsR(),
+        ]
+    )
 
 
 def rewrite_rx_as_r(theta: float) -> Instruction:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch adds `AQTEstimator`, a specialized implementation of the [`Estimator`](https://qiskit.org/documentation/apidoc/primitives.html#overview-of-estimator) primitive.

Like for `AQTSampler` added in #60, it is necessary to use the specialized implementation when evaluating the primitive on parametrized circuits because the AQT transpiler plugin cannot work on circuits with unbound parameters.

To illustrate the use of `AQTEstimator`, a trivial VQE example was added.