### PR TITLE
backends: add noisy offline simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `AQTEstimator`, a specialized implementation of the `Estimator` primitive #71
 * Add simple VQE example #71
 * Update pinned dependencies #72
+* Add `offline_simulator_noise` resource with basic noise model #73
 
 ## qiskit-aqt-provider v0.13.0
 

--- a/examples/example_noise.py
+++ b/examples/example_noise.py
@@ -1,0 +1,49 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Basic example with the Qiskit AQT provider and the noisy offline simulator.
+
+Creates a 2-qubit GHZ state.
+"""
+
+
+import qiskit
+from qiskit import QuantumCircuit
+
+from qiskit_aqt_provider.aqt_provider import AQTProvider
+
+if __name__ == "__main__":
+    # If no `access_token` is passed to the constructor it is read from
+    # the AQT_TOKEN environment variable
+    provider = AQTProvider("token")
+
+    # The backends() method lists all available computing backends. Printing it
+    # renders it as a table that shows each backend's containing workspace.
+    print(provider.backends())
+
+    # Retrieve a backend by providing search criteria. The search must have a single
+    # match. For example:
+    backend = provider.get_backend("offline_simulator_noise", workspace="default")
+
+    # Create a 2-qubit GHZ state
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure_all()
+
+    result = qiskit.execute(qc, backend, shots=200).result()
+
+    if result.success:
+        # due to the noise, also the states '01' and '10' may be populated!
+        print(result.get_counts())
+    else:  # pragma: no cover
+        print(result.to_dict()["error"])

--- a/qiskit_aqt_provider/aqt_provider.py
+++ b/qiskit_aqt_provider/aqt_provider.py
@@ -60,6 +60,7 @@ class OfflineSimulator:
 
 OFFLINE_SIMULATORS: Final = [
     OfflineSimulator(id="offline_simulator_no_noise", name="Offline ideal simulator", noisy=False),
+    OfflineSimulator(id="offline_simulator_noise", name="Offline noisy simulator", noisy=True),
 ]
 
 

--- a/qiskit_aqt_provider/test/fixtures.py
+++ b/qiskit_aqt_provider/test/fixtures.py
@@ -29,13 +29,13 @@ from qiskit_aqt_provider.circuit_to_aqt import _qiskit_to_aqt_circuit
 class MockSimulator(OfflineSimulatorResource):
     """Offline simulator that keeps track of the submitted circuits."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, noisy: bool) -> None:
         super().__init__(
             AQTProvider(""),
             workspace_id="default",
             resource_id="mock_simulator",
             resource_name="mock_simulator",
-            noisy=False,
+            noisy=noisy,
         )
 
         self.submit_call_args: List[Tuple[List[QuantumCircuit], int]] = []
@@ -74,4 +74,4 @@ class MockSimulator(OfflineSimulatorResource):
 @pytest.fixture(name="offline_simulator_no_noise")
 def fixture_offline_simulator_no_noise() -> MockSimulator:
     """Noiseless offline simulator resource."""
-    return MockSimulator()
+    return MockSimulator(noisy=False)

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -17,6 +17,7 @@ expected.
 """
 
 import re
+from collections import Counter
 from fractions import Fraction
 from math import pi
 from typing import List
@@ -32,6 +33,7 @@ from qiskit_experiments.library import QuantumVolume
 
 from qiskit_aqt_provider.aqt_resource import AQTResource
 from qiskit_aqt_provider.test.circuits import qft_circuit
+from qiskit_aqt_provider.test.fixtures import MockSimulator
 from qiskit_aqt_provider.test.resources import TestResource
 from qiskit_aqt_provider.test.timeout import timeout
 
@@ -126,6 +128,35 @@ def test_simple_backend_execute(shots: int, offline_simulator_no_noise: AQTResou
     # qiskit.execute calls the transpiler automatically
     job = qiskit.execute([qc0, qc1], backend=offline_simulator_no_noise, shots=shots)
     assert job.result().get_counts() == [{"01": shots}, {"10": shots}]
+
+
+@pytest.mark.parametrize("backend", [MockSimulator(noisy=False), MockSimulator(noisy=True)])
+def test_simple_backend_execute_noisy(backend: MockSimulator) -> None:
+    """Execute a simple circuit on a noisy and noiseless backend. Check that the noisy backend
+    is indeed noisy.
+    """
+    qc = QuantumCircuit(1)
+    qc.rx(pi, 0)
+    qc.measure_all()
+
+    # the single qubit error is around 0.1% so to see at least one error, we need to do more than
+    # 1000 shots.
+    total_shots = 4000  # take some margin
+    shots = 200  # maximum shots per submission
+    assert total_shots % shots == 0
+
+    counts: Counter[str] = Counter()
+    for _ in range(total_shots // shots):
+        job = qiskit.execute(qc, backend=backend, shots=shots)
+        counts += Counter(job.result().get_counts())
+
+    assert sum(counts.values()) == total_shots
+
+    if backend.noisy:
+        assert set(counts.keys()) == {"0", "1"}
+        assert counts["0"] < 0.1 * counts["1"]  # very crude
+    else:
+        assert set(counts.keys()) == {"1"}
 
 
 @pytest.mark.parametrize("shots", [100])

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -17,6 +17,7 @@ expected.
 """
 
 import re
+import typing
 from collections import Counter
 from fractions import Fraction
 from math import pi
@@ -145,7 +146,7 @@ def test_simple_backend_execute_noisy(backend: MockSimulator) -> None:
     shots = 200  # maximum shots per submission
     assert total_shots % shots == 0
 
-    counts: Counter[str] = Counter()
+    counts: typing.Counter[str] = Counter()
     for _ in range(total_shots // shots):
         job = qiskit.execute(qc, backend=backend, shots=shots)
         counts += Counter(job.result().get_counts())

--- a/test/test_transpilation.py
+++ b/test/test_transpilation.py
@@ -71,7 +71,7 @@ def test_rx_ry_rewrite_transpile(
     assume(abs(theta) > pi / 200)
 
     # we only need the backend's transpiler target for this test
-    backend = MockSimulator()
+    backend = MockSimulator(noisy=False)
 
     qc = QuantumCircuit(1)
     qc.append(test_gate(theta), (0,))
@@ -211,7 +211,7 @@ def test_rxx_wrap_angle_transpile(angle: float, qubits: int, optimization_level:
     qc.rxx(angle, 0, 1)
 
     # we only need the backend's transpilation target for this test
-    backend = MockSimulator()
+    backend = MockSimulator(noisy=False)
     trans_qc = transpile(qc, backend, optimization_level=optimization_level)
     assert isinstance(trans_qc, QuantumCircuit)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch adds a noisy offline simulator backend with a minimal noise model.

:warning: The noise model is provided for illustration purposes only and only loosely corresponds to the capabilities of the AQT machines.

### Details and comments

- added an example with the noisy simulator, which is the same as the basic example, just to check that one can access the resource by name.
