### PR TITLE
Provider: make the access token optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Make the access token optional #80
+
 ## qiskit-aqt-provider v0.15.0
 
 * Set default portal url to `https://arnica-stage.aqt.eu` #79

--- a/examples/example.py
+++ b/examples/example.py
@@ -19,8 +19,11 @@ from qiskit import QuantumCircuit
 from qiskit_aqt_provider.aqt_provider import AQTProvider
 
 if __name__ == "__main__":
-    # If no `access_token` is passed to the constructor it is read from
-    # the AQT_TOKEN environment variable
+    # Ways to specify an access token (in precedence order):
+    # - as argument to the AQTProvider initializer
+    # - in the AQT_TOKEN environment variable
+    # - if none of the above exists, default to an empty string, which restricts access
+    #   to the default workspace only.
     provider = AQTProvider("token")
 
     # The backends() method lists all available computing backends. Printing it

--- a/examples/example_noise.py
+++ b/examples/example_noise.py
@@ -22,8 +22,11 @@ from qiskit import QuantumCircuit
 from qiskit_aqt_provider.aqt_provider import AQTProvider
 
 if __name__ == "__main__":
-    # If no `access_token` is passed to the constructor it is read from
-    # the AQT_TOKEN environment variable
+    # Ways to specify an access token (in precedence order):
+    # - as argument to the AQTProvider initializer
+    # - in the AQT_TOKEN environment variable
+    # - if none of the above exists, default to an empty string, which restricts access
+    #   to the default workspace only.
     provider = AQTProvider("token")
 
     # The backends() method lists all available computing backends. Printing it

--- a/examples/grover-3-sat.py
+++ b/examples/grover-3-sat.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
     try:
         import tweedledum
-    except ImportError:
+    except ImportError:  # pragma: no cover
         print("Tweedledum not available: example not supported.", file=sys.stderr)
         sys.exit(0)  # not a critical error
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With this patch, the access token for the AQT portal is completely optional. If no token is passed, access is restricted to the `default` workspace.

In order to ease up local setups, a warning is emitted when no token is found. This warning can be ignored using a [warnings filter](https://docs.python.org/3/library/warnings.html#the-warnings-filter), e.g.

```bash
python -W ignore:'No access token' path/to/script.py
```

### Details and comments

- the workspace restriction is driven by the portal not accepting empty tokens
- unchanged: the `default` workspace is created ad-hoc in the provider, to host the offline simulators.