### PR TITLE
Fix ignored flaky tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,11 +12,13 @@
 
 """Pytest dynamic configuration."""
 
+from datetime import timedelta
+
 import hypothesis
 
 hypothesis.settings.register_profile(
-    "default",
-    deadline=None,  # Account for slower CI workers
+    "ci",
+    deadline=timedelta(seconds=1),  # Account for slower CI workers
     print_blob=True,  # Always print code to use with @reproduce_failure
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,8 +213,8 @@ fail_under = 98
 
 [tool.poe.tasks.test]
 shell = """
-coverage run ${cov_opts} -m pytest
 set -eu
+coverage run ${cov_opts} -m pytest --hypothesis-profile=ci
 coverage report
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ fail_under = 98
 [tool.poe.tasks.test]
 shell = """
 coverage run ${cov_opts} -m pytest
+set -eu
 coverage report
 """
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch fixes pipeline issues observed e.g. in job [9832513795](https://github.com/alpine-quantum-technologies/qiskit-aqt-provider-rc/actions/runs/5410706778/jobs/9832513795) where a test failure in `test_transpilation` didn't fail the job.

Changes:

1. Make sure the shell task `test` fails if any of its components does, not only the last one. By default, the `poe` shell tasks just execute their content in the given shell (bash by default), which results in the shell exit code being the exit code of the last command. Using `set -e`, the script returns early in case of failure.
2. Properly set the deadline for hypothesis examples. Registering a profile named `default` doesn't work to override the default settings.
